### PR TITLE
Updated Flash Macro Documentation

### DIFF
--- a/Notification/README.md
+++ b/Notification/README.md
@@ -277,7 +277,14 @@ The following example uses the default values of flash.
 
 1. This is how to use JavaScript to create flash messages with the default parameters.
     - ```js
-      window.FlashMessage.default('Lorem ipsum dolor sit amet, consectetur adipiscing elit.', {
+      window.FlashMessage.create(
+          /* Text to be displayed. */
+          'Lorem ipsum dolor sit amet, consectetur adipiscing elit.', 
+          /* Type of message to display. The following strings are accepted: 
+           * "success", "warning", "error", "info", "bug", "disabled", "default" */
+          "success",
+          /* Other Settings */
+          {
           progress: true,
           interactive: true,
           timeout: 8000,
@@ -288,9 +295,36 @@ The following example uses the default values of flash.
           classes: {
               container: 'flash-container',
               flash: 'flash-message',
-              visible: 'is-visible',
+              visible: 'flash-is-visible',
               progress: 'flash-progress',
-              progress_hidden: 'is-hidden'
+              progress_hidden: 'flash-is-hidden'
           }
       });
       ```
+
+2. To quickly test in your SugarCube project, insert:
+    - ```html
+        <<button "JS Flash!">>
+            <<script>>
+                window.FlashMessage.create(
+                    'This example contributed by LeahPeach c:', 
+                    "success",
+                    {
+                    progress: true,
+                    interactive: true,
+                    timeout: 8000,
+                    appear_delay: 200,
+                    container: '.flash-container',
+                    theme: 'default',
+                    layout: 'top-right',
+                    classes: {
+                        container: 'flash-container',
+                        flash: 'flash-message',
+                        visible: 'flash-is-visible',
+                        progress: 'flash-progress',
+                        progress_hidden: 'flash-is-hidden'
+                    }
+                });
+            <</script>>
+        <</button>>
+        ```


### PR DESCRIPTION
This updates your documentation for the JavaScript portion of your ported Flash Macro, which contained some errors.

1. `FlashMessage.default()` simply doesn't exist, the function is `FlashMessage.create()`.
2. Added, as a comment to the example, that we need to provide the `type` of the message as an argument, as the `type: "whatever"` property doesn't work in the object. If we do that, it will always show as an `error type`. **This is likely a bug.**
3. Updated the classes so that they all start with `flash`, e.g. `flash-is-hidden` instead of `is-hidden`.
4. I provided an example that people can copy and paste into their SugarCube project for ease of testing.